### PR TITLE
Remove sourceMappingURL from manifest source if using sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+var sourceMappingURL = require('source-map-url')
+
 function InlineManifestPlugin(options) {}
 
 InlineManifestPlugin.prototype.apply = function(compiler) {
@@ -7,7 +9,12 @@ InlineManifestPlugin.prototype.apply = function(compiler) {
 
             for(var key in compilation.assets){
                 if(key.indexOf('manifest.') > -1){
-                    manifest = compilation.assets[key].source();
+                    // manifestSource will include the //# sourceMappingURL line if
+                    // using sourcemaps so we need to remove
+                    var manifestSource = compilation.assets[key].source()
+                    var manifestSourceWithoutSourceMapUrl = sourceMappingURL.removeFrom(manifestSource)
+
+                    manifest = manifestSourceWithoutSourceMapUrl;
                     break;
                 }
             }

--- a/package.json
+++ b/package.json
@@ -19,5 +19,8 @@
   ],
   "author": "szrenwei <shizairw@gmail.com> (https://github.com/szrenwei)",
   "license": "MIT",
-  "homepage": "https://github.com/szrenwei/inline-manifest-webpack-plugin"
+  "homepage": "https://github.com/szrenwei/inline-manifest-webpack-plugin",
+  "dependencies": {
+    "source-map-url": "0.4.0"
+  }
 }


### PR DESCRIPTION
When using source maps (for your other assets), the manifest source will look something like this (note the sourceMappingURL on the final line):

```
!function(e){function t(n){if(a[n])return a[n].exports......
//# sourceMappingURL=manifest.b301ea83779dd8dbe7d6.js.map
```

This doesn't really make sense when injecting as a script tag into your html, so this pull request will remove this line if it exists
