### PR TITLE
new option to wrap manifest in script tags to reduce template logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 var sourceMappingURL = require('source-map-url')
 
 function InlineManifestPlugin(options) {
-	this.options = extend({name: 'webpackManifest'}, options)
+	this.options = extend({
+		name: 'webpackManifest',
+		wrapManifestInScriptTags: false
+	}, options)
 }
 
 InlineManifestPlugin.prototype.apply = function(compiler) {
@@ -20,6 +23,11 @@ InlineManifestPlugin.prototype.apply = function(compiler) {
                 if(key.indexOf('manifest.') > -1){
 					// remove sourceMap url if exist
 					webpackManifest = sourceMappingURL.removeFrom(compilation.assets[key].source())
+					
+					if (me.options.wrapManifestInScriptTags) {
+						webpackManifest = '<script>' + webpackManifest + '</script>';
+					}
+					
                     break
                 }
             }


### PR DESCRIPTION
Added a new option so that you can have the manifest wrapped in a script tag.

This allows you to reduce the logic in the html template from

```
<% if(htmlWebpackPlugin.files.webpackManifest){ %>
<script>
    <%=htmlWebpackPlugin.files.webpackManifest%>
</script>
<% } %>
```

to just

```
<%=htmlWebpackPlugin.files.webpackManifest%>
```

I have set the default to `false` so it's not a breaking change.

If you do not want this option in your library, feel free to close this pull request.
