### PR TITLE
bugfix:when script.src is null ,inlineWhenMatched will throw error

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ function getAssetName (chunks, chunkName) {
 
 function inlineWhenMatched (compilation, scripts, manifestAssetName) {
     return scripts.map(function (script) {
-        var isManifestScript = script.tagName === 'script' &&
+        var isManifestScript = script.tagName === 'script' && script.attributes.src &&
               (script.attributes.src.indexOf(manifestAssetName) >= 0)
 
         if (isManifestScript) {


### PR DESCRIPTION
when I has other script inline, `script.attributes.src.indexOf(manifestAssetName) >= 0` will throw error. 
当我有其他内联的脚本时，这里的判断不够健壮会报错